### PR TITLE
remove default fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function dotpathStream(path, fallback) {
     var value = lookup(data)
 
     if(typeof value === 'undefined') {
-      value = typeof fallback === 'undefined' ? {} : fallback
+      value = fallback
     }
 
     this.queue(value)

--- a/test/index.js
+++ b/test/index.js
@@ -68,13 +68,13 @@ test('fallback can be falsey', function(t) {
   stream.write({})
 })
 
-test('fallback defaults to {}', function(t) {
+test('fallback has no default', function(t) {
   t.plan(1)
 
   var stream = dps('hello.beakmans')
 
   stream.once('data', function(data) {
-    t.deepEqual(data, {})
+    t.equal(data, undefined)
   })
 
   stream.write({herp: 'derp'})


### PR DESCRIPTION
don't default to `{}`, just use one if its present
